### PR TITLE
Remove ipv6 code-path and other minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 *.pdb
 
 cfg.toml
+Cargo.lock

--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,15 @@ pub struct WifiConfig {
 }
 
 fn main() {
+    let cfg = std::path::Path::new("cfg.toml");
+
     // Checks whether Wi-FI configuration exists
-    if !std::path::Path::new("cfg.toml").exists() {
+    if !cfg.exists() {
         panic!("A `wifi_config.toml` file with Wi-Fi credentials is required! Use `wifi_config.toml.example` as a template.");
     }
+
+    // Track the `cfg.toml` file so that you get a rebuild upon changes to it
+    embuild::cargo::track_file(cfg);
 
     let wifi_config = WIFI_CONFIG;
     if wifi_config.ssid == "your Wi-Fi SSID" || wifi_config.password == "your Wi-Fi password" {


### PR DESCRIPTION
@Luni-4 The TL;DR is: you don't have a valid ipv6 addr assigned on the ESP IDF Wifi interface, yet you are configuring the mDNS responder as if you have one.
